### PR TITLE
Strip leading space

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ module.exports = toSpaceCase;
 
 
 function toSpaceCase (string) {
-  return clean(string).replace(/[\W_]+(.|$)/g, function (matches, match) {
-    return match ? ' ' + match : '';
+  return clean(string).replace(/(^|.)[\W_]+(.|$)/g, function (matches, left, right) {
+    return left && right ? left + ' ' + right : left + right;
   });
 }

--- a/test/index.js
+++ b/test/index.js
@@ -23,4 +23,7 @@ describe('to-space-case', function () {
 
   for (var key in strings) convert(key);
 
+  it('should not leave space at the ends of a string', function () {
+    assert('this is a string' == space('_this_is_a_string_'));
+  });
 });


### PR DESCRIPTION
Hi!

Currently trailing space is stripped from a transformed string:

``` js
> spaceCase('foo-')
'foo'
```

However, leading space is preserved:

``` js
> spaceCase('-foo')
' foo'
```

This patch fixes this asymmetry by stripping leading space, too.
